### PR TITLE
Update the minimum CMake required.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(control_box_rst)
 
 set(MESSAGE_SUPPORT OFF CACHE BOOL "Message support (downloads and compiles Protobuf)" FORCE)


### PR DESCRIPTION
Newer versions of cmake warn that compatibility before CMake 3.5 is deprecated.  Since CMake 3.5 was released in 2016, we can safely update this.