### PR TITLE
Fix pushJacobian() returning VectorXd& instead of MatrixXd& on C++17

### DIFF
--- a/src/optimization/include/corbo-optimization/hyper_graph/edge_cache.h
+++ b/src/optimization/include/corbo-optimization/hyper_graph/edge_cache.h
@@ -75,7 +75,7 @@ class EdgeCache
         PRINT_DEBUG_COND_ONCE(_jacobians.size() >= _values.capacity(),
                               "EdgeCache::pushJacobian(): cache capacity reached; you might better reserve more space in advance.");
 #if __cplusplus > 201402L
-        return _values.emplace_back();
+        return _jacobians.emplace_back(value_dim, param_dim);
 #else
         _jacobians.emplace_back(value_dim, param_dim);
         return _jacobians.back();


### PR DESCRIPTION
## What

`EdgeCache::pushJacobian()` fails to compile in C++17 mode with:

```
error: non-const lvalue reference to type 'Eigen::Matrix<double, -1, -1>' cannot bind
       to a value of unrelated type 'Eigen::Matrix<double, -1, 1>'
```

## Why

`pushJacobian()` returns `Eigen::MatrixXd&`, but its C++17 fast-path returns `_values.emplace_back()` — and `_values` is a `std::vector<Eigen::VectorXd>`, so it yields a `VectorXd&`. It was copy-pasted from `pushValues()` and the vector name was never changed to `_jacobians`. The pre-C++17 `#else` branch is already correct (`_jacobians.emplace_back(value_dim, param_dim)`), so the bug is dormant on C++14 and only surfaces on C++17.

## Fix

Use the jacobian vector in the C++17 branch too:

```cpp
#if __cplusplus > 201402L
    return _jacobians.emplace_back(value_dim, param_dim);
#else
    ...
```

Verified: `std::vector<Eigen::MatrixXd>::emplace_back(rows, cols)` returns `Eigen::MatrixXd&` in C++17, matching the function's return type.

---
## Tested on
- **macOS 26** (Apple Silicon / arm64) — GitHub Actions `macos-26` runners
- **Apple clang 21.0.0** (`clang-2100.1.1.101`, target `arm64-apple-darwin25.5.0`), C++17, libc++
- Built from source in a ROS 2 (Humble / Jazzy / Kilted) workspace (CMake 4.3)
- Environment: Homebrew Boost 1.90 + vendored Boost 1.89, fmt 12.2.0
- Linux behaviour unchanged (platform-specific paths are guarded / equivalent).